### PR TITLE
Kakao Message 친구 목록 가져오기

### DIFF
--- a/src/main/java/com/fastcampus/pass/adapter/message/KakaoTalkMessageAdapter.java
+++ b/src/main/java/com/fastcampus/pass/adapter/message/KakaoTalkMessageAdapter.java
@@ -1,0 +1,36 @@
+package com.fastcampus.pass.adapter.message;
+
+import com.fastcampus.pass.config.KakaoTalkMessageConfig;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class KakaoTalkMessageAdapter {
+    private final WebClient webClient;
+
+    public KakaoTalkMessageAdapter(KakaoTalkMessageConfig config) {
+        webClient = WebClient
+                .builder()
+                .baseUrl(config.getHost())
+                .defaultHeaders(h -> {
+                    h.setBearerAuth(config.getToken());
+                    h.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                }).build();
+    }
+
+    public boolean sendKakaoTalkMessage(final String uuid, final String text) {
+        KakaoTalkMessageResponse response  = webClient
+                .post()
+                .uri("/v1/api/talk/friends/message/default/send")
+                .retrieve()
+                .bodyToMono(KakaoTalkMessageResponse.class)
+                .block();
+
+        if (response == null || response.getSuccessfulReceiverUuids() == null) {
+            return false;
+        }
+        return response.getSuccessfulReceiverUuids().size() > 0;
+    }
+}

--- a/src/main/java/com/fastcampus/pass/adapter/message/KakaoTalkMessageRequest.java
+++ b/src/main/java/com/fastcampus/pass/adapter/message/KakaoTalkMessageRequest.java
@@ -1,0 +1,52 @@
+package com.fastcampus.pass.adapter.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class KakaoTalkMessageRequest {
+    @JsonProperty("template_object")
+    private TemplateObject templateObject;
+
+    @JsonProperty("receiver_uuids")
+    private List<String> receiverUuids;
+
+    @Getter
+    @Setter
+    @ToString
+    public static class TemplateObject {
+        @JsonProperty("object_type")
+        private String objectType;
+        private String text;
+        private Link link;
+
+        @Getter
+        @Setter
+        @ToString
+        public static class Link {
+            @JsonProperty("web_url")
+            private String webUrl;
+        }
+    }
+
+    public KakaoTalkMessageRequest(String uuid, String text) {
+        List<String> receiverUuids = Collections.singletonList(uuid);
+
+        TemplateObject.Link link = new TemplateObject.Link();
+        TemplateObject templateObject = new TemplateObject();
+        templateObject.setObjectType("test");
+        templateObject.setText(text);
+        templateObject.setLink(link);
+
+        this.receiverUuids = receiverUuids;
+        this.templateObject = templateObject;
+    }
+
+}

--- a/src/main/java/com/fastcampus/pass/adapter/message/KakaoTalkMessageResponse.java
+++ b/src/main/java/com/fastcampus/pass/adapter/message/KakaoTalkMessageResponse.java
@@ -1,0 +1,21 @@
+package com.fastcampus.pass.adapter.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class KakaoTalkMessageResponse {
+    // json : successful_receiver_uuids <-> Java 객체 : successfulReceiverUuids field mapping
+    // {
+    //    "successful_receiver_uuids": ["uuid1", "uuid2", "uuid3"]
+    // }
+    // 의 Json 을 List<String> 으로 mapping
+    @JsonProperty("successful_receiver_uuids")
+    private List<String> successfulReceiverUuids;
+}

--- a/src/main/java/com/fastcampus/pass/config/KakaoTalkMessageConfig.java
+++ b/src/main/java/com/fastcampus/pass/config/KakaoTalkMessageConfig.java
@@ -1,0 +1,15 @@
+package com.fastcampus.pass.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kakaotalk") // application.ymal 에서 kakao.host / kakao.token 설정값을 가져와서 사용할 있도록 해줌
+public class KakaoTalkMessageConfig {
+    private String host;
+    private String token;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,3 +12,6 @@ spring:
       initialize-schema: always
       isolation-level-for-create: default
 
+kakaotalk:
+  host: https://kapi.kakao.com
+  token: YOUR_ACCESS_TOKEN


### PR DESCRIPTION
카카오 message API 를 통하여 내 카카오톡 친구 정보를 가져오고 message 를 보낼 수 있는 기능에 대한 데이터 처리 및 설정을 추가하였으나, 실제로 해당 내용을 제대로 학습하지 않아 추후 내용의 이해 및 추가 구현이 필요한 상태이다. 

This closes #16